### PR TITLE
Add test results download step and coverage report path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,11 +48,17 @@ jobs:
 
   sonarcloud:
     name: SonarCloud
+    needs: test
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Download test results
+        uses: actions/download-artifact@v2
+        with:
+          name: test-results
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,4 +7,4 @@ sonar.inclusions=**,.github/ci.yaml,.devcontainer/Dockerfile
 sonar.python.version=3.11
 # enable debug logging
 sonar.verbose=true
-
+sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
This commit adds a new step to download test results and sets the coverage report path in the SonarCloud configuration.