### PR TITLE
Use mock and stubbed data for test

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
 	//"forwardPorts": [8888]
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip install pytest-bdd"
+	"postCreateCommand": "pip install -r src/requirements.txt"
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"

--- a/notebooks/temp.py
+++ b/notebooks/temp.py
@@ -1,4 +1,0 @@
-# SonarLint extension for VSCode supports Python and iPython Notebooks
-# SonarQube and SonarCloud support Python but NOT iPython Notebooks
-# This file was created to test SonarLint and SonarQube/SonarCloud could find and scan a python file
-print("Hello, World!")

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 These experimental jupyter notebooks plot inflation, interest rate and SPX 500 index to help visualize investment and retirement portfolios.
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=mikejonestechno_investment-analytics&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=mikejonestechno_investment-analytics) 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=mikejonestechno_investment-analytics&metric=alert_status)](https://sonarcloud.io/summary/overall?id=mikejonestechno_investment-analytics) 
 
 Code Quality automatically scanned and published on SonarCloud. Although SonarQube can scan python files for code quality, it does not currently support python code in Jupyter notebook files.
 

--- a/src/data_loader_test.py
+++ b/src/data_loader_test.py
@@ -9,12 +9,10 @@ scenarios('data_loader.feature')
 
 # Define the given step
 @given('the local file does not exist', target_fixture="local_file_name")
-def local_file():
-    local_file = 'test.csv'
-    if os.path.exists(local_file):
-        os.remove(local_file)
-    return local_file
-
+def local_file(tmp_path):
+    # pytest tmp_path is unique for each test run, file guranteed to not exist
+    temp_file = tmp_path / "pytest.csv"
+    return str(temp_file)
 
 def mock_urlretrieve_csv_data_stub(url, filename, *args, **kwargs):
     # Create file with CSV data stub
@@ -24,7 +22,6 @@ def mock_urlretrieve_csv_data_stub(url, filename, *args, **kwargs):
         writer.writerow(['2024-01-01', '140'])
         writer.writerow(['2024-01-02', '150'])
     return (filename, None)
-
 
 # Define the when step
 @when('I call load_data', target_fixture="call_load_data")
@@ -41,5 +38,6 @@ def call_load_data(mocker, local_file_name):
 # Define the then step
 @then('a new file is downloaded')
 def new_file_is_downloaded(call_load_data):
+    # call_load_data yeilds the dataframe and the mock_urlretrieve object, ignore df object using '_'
     _, mock_urlretrieve = call_load_data
     mock_urlretrieve.assert_called_once()

--- a/src/data_loader_test.py
+++ b/src/data_loader_test.py
@@ -1,28 +1,45 @@
 import os
-import pytest
 from pytest_bdd import scenarios, given, when, then
 from data_loader import load_data
+from tempfile import NamedTemporaryFile
+import csv
 
 # Define the scenario
 scenarios('data_loader.feature')
 
 # Define the given step
-@given('the local file does not exist',target_fixture="local_file_name")
+@given('the local file does not exist', target_fixture="local_file_name")
 def local_file():
     local_file = 'test.csv'
     if os.path.exists(local_file):
         os.remove(local_file)
     return local_file
 
+
+def mock_urlretrieve_csv_data_stub(url, filename, *args, **kwargs):
+    # Create file with CSV data stub
+    with open(filename, mode='w') as f:
+        writer = csv.writer(f)
+        writer.writerow(['date', 'price'])
+        writer.writerow(['2024-01-01', '140'])
+        writer.writerow(['2024-01-02', '150'])
+    return (filename, None)
+
+
 # Define the when step
-@when('I call load_data')
-def call_load_data(local_file_name):
-    csv_url = 'https://people.sc.fsu.edu/~jburkardt/data/csv/hw_200.csv'
+@when('I call load_data', target_fixture="call_load_data")
+def call_load_data(mocker, local_file_name):
+    csv_url = 'https://mock.test.com/data.csv'
     max_age_days = 1
+
+    # mock urlretrieve to intercept the download and return the CSV data stub
+    mock_urlretrieve = mocker.patch('urllib.request.urlretrieve', side_effect=mock_urlretrieve_csv_data_stub)
+
     df = load_data(csv_url, local_file_name, max_age_days)
-    return df
+    yield df, mock_urlretrieve
 
 # Define the then step
 @then('a new file is downloaded')
-def new_file_is_downloaded(local_file_name):
-    assert os.path.exists(local_file_name)
+def new_file_is_downloaded(call_load_data):
+    _, mock_urlretrieve = call_load_data
+    mock_urlretrieve.assert_called_once()

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,4 @@
 pytest-bdd
 pytest-cov
+pytest-mock
 pandas


### PR DESCRIPTION
Refactor test to use temporary local_file

Previously, the test for the `load_data` function relied on downloading a CSV file from a remote URL. This PR introduces a mock and stubbed data approach to the test. It also refactors the test to use a temporary local file, created using the `tempfile` module, instead of relying on an existing file. This improves the reliability and speed of the test, as it no longer requires an internet connection or a specific file to be present.