### PR TITLE
Add VS Code extensions and update SonarQube configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,10 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
+				"jupyter.vscode-jupyter",
+				"ms-python.vscode-pylance",
+				"ms-python.python",
+				"github.vscode-pull-request-github",
 				"github.copilot",
 				"SonarSource.sonarlint-vscode"
 			]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,7 @@ sonar.organization=mikejonestechno
 sonar.sources=.
 # include hidden directories
 sonar.inclusions=**,.github/ci.yaml,.devcontainer/Dockerfile
+sonar.exclusions=coverage*.xml,test*.xml
 sonar.python.version=3.11
 # enable debug logging
 sonar.verbose=true


### PR DESCRIPTION
This pull request adds the following VS Code extensions: jupyter.vscode-jupyter, ms-python.vscode-pylance, ms-python.python, github.vscode-pull-request-github, github.copilot, and SonarSource.sonarlint-vscode. It also updates the SonarQube configuration to exclude coverage*.xml and test*.xml files.