### PR TITLE
Remove powershell feature from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,8 @@
 		"context": "..",
 		"dockerfile": "Dockerfile"
 	},
+	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers/features/powershell:1": {},
 		"ghcr.io/devcontainers/features/node:1": {}
 	},
 
@@ -24,9 +24,6 @@
 			]
 		}
 	},
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	//"forwardPorts": [8888]


### PR DESCRIPTION
This pull request removes the powershell feature from the devcontainer. The powershell feature is no longer needed and has been replaced with the node feature. This change simplifies the devcontainer configuration and reduces unnecessary dependencies.