### PR TITLE
Update Jupyter extension in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"jupyter.vscode-jupyter",
+				"ms-toolsai.jupyter",
 				"ms-python.vscode-pylance",
 				"ms-python.python",
 				"github.vscode-pull-request-github",


### PR DESCRIPTION
This pull request updates the Jupyter extension in the devcontainer.json file to use the "ms-toolsai.jupyter" extension instead of the "jupyter.vscode-jupyter" extension.