### PR TITLE
Update SonarQube configuration to exclude test-results directory

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,10 +4,10 @@ sonar.organization=mikejonestechno
 sonar.sources=.
 # include hidden directories
 sonar.inclusions=**,.github/ci.yaml,.devcontainer/Dockerfile
-sonar.exclusions=coverage*.xml,test*.xml
+sonar.exclusions=test-results/**
 sonar.python.version=3.11
 # enable debug logging
 # sonar.verbose=true
 sonar.test.inclusions=**/*_test.py
-sonar.python.coverage.reportPaths=coverage.xml
 sonar.coverage.exclusions=**/*_test.py
+sonar.python.coverage.reportPaths=test-results/coverage.xml


### PR DESCRIPTION
This pull request updates the SonarQube configuration to exclude the "test-results" directory from analysis. This change ensures that the test results are not included in the code coverage calculations.