### PR TITLE
Add pytest.ini and set test paths to src directory

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = src


### PR DESCRIPTION
This pull request adds a pytest.ini file to the repository and sets the test paths to the src directory. This will allow the tests to be run from the correct location and ensure that the test coverage is accurate.