### PR TITLE
Add theme to GitHub Pages

### DIFF
--- a/pages/_config.yml
+++ b/pages/_config.yml
@@ -1,0 +1,7 @@
+title: Investment Analytics
+description: An experimental project for investment and retirement data analytics.
+#theme: jekyll-theme-minimal # try slate theme?
+remote_theme: pages-themes/architect@v0.2.0
+plugins:
+- jekyll-remote-theme # add this line to the plugins list if you already have one
+show_downloads: false


### PR DESCRIPTION
This pull request adds a theme to the GitHub Pages site. The theme used is "pages-themes/architect@v0.2.0". 