### PR TITLE
Update CI workflow to trigger PRs even if only pages are changed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,7 @@ on:
       - 'pages/**'      
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'pages/**'      
+    # due to the branch protection rule, the PR must be triggered even if only pages are changed
 jobs:
   test:
     name: Unit Test


### PR DESCRIPTION
This pull request updates the CI workflow to trigger pull requests even if only the pages directory is changed. This is necessary due to a branch protection rule.