### PR TITLE
Add GitHub social link to _config.yml

### DIFF
--- a/pages/_config.yml
+++ b/pages/_config.yml
@@ -2,7 +2,7 @@ title: Investment Analytics
 description: An experimental project for investment and retirement data analytics.
 #theme: jekyll-theme-primer
 theme: minima
-#remote_theme: pages-themes/minima@v0.2.0
-#plugins:
-#- jekyll-remote-theme
-#show_downloads: false
+
+minima:
+  social_links:
+    - { platform: github, user_url: "https://github.com/mikejonestechno" }


### PR DESCRIPTION
This pull request adds a GitHub social link to the _config.yml file, allowing users to easily access the developer's GitHub profile.