### PR TITLE
Update syntax of WordPress social in _config.yml

### DIFF
--- a/pages/_config.yml
+++ b/pages/_config.yml
@@ -25,4 +25,5 @@ minima:
     - { platform: github, user_url: "https://github.com/mikejonestechno" }
     - { platform: linkedin, user_url: "https://www.linkedin.com/in/mikejonestechno/" }
     - { platform: youtube, user_url: "https://www.youtube.com/@MikeJonesTechno" }
-    - { platform: wordpress, user_url: "https://mikejonestechno.wordpress.com/" }
+    - platform: wordpress
+      user_url: "https://mikejonestechno.wordpress.com/"


### PR DESCRIPTION
This pull request updates the syntax of the WordPress social platform in the _config.yml file. The user_url for the WordPress platform has been modified to "https://mikejonestechno.wordpress.com/".