### PR TITLE
Update notebook conversion script to convert notebooks in a specific directory

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -30,6 +30,6 @@ jobs:
 
     - name: Convert notebooks to Markdown
       run: |
-        for notebook in *.ipynb; do
-          jupyter nbconvert --to markdown "$notebook"
+        for notebook in notebooks/*.ipynb; do
+          jupyter nbconvert --to markdown "$notebook" --output-dir="./pages/notebooks" --debug
         done        


### PR DESCRIPTION
This pull request updates the notebook conversion script to convert notebooks in a specific directory. Previously, the script converted all notebooks in the current directory, but now it converts notebooks in the "notebooks" directory and outputs the converted files to the "./pages/notebooks" directory. This change improves the organization of the converted files and ensures that only the desired notebooks are converted.