### PR TITLE
Convert notebooks to Markdown and upload for debugging

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -29,7 +29,13 @@ jobs:
         pip install nbconvert
 
     - name: Convert notebooks to Markdown
-      run: |
-        for notebook in notebooks/*.ipynb; do
-          jupyter nbconvert --to markdown "$notebook" --output-dir="./pages/notebooks" --debug
-        done        
+      run: jupyter nbconvert --to=markdown --output-dir="./pages/notebooks" --debug notebooks/inflation.ipynb        
+        # for notebook in notebooks/inflation.ipynb; do
+        #  jupyter nbconvert --to=markdown --output-dir="./pages/notebooks" --debug "$notebook"
+        # done        
+
+    - name: Upload for Debugging
+      uses: actions/upload-artifact@v4
+      with:
+        name: notebooks
+        path: pages/notebooks/


### PR DESCRIPTION
This pull request converts the notebooks to Markdown format and uploads them for debugging purposes. The `jupyter nbconvert` command is used to convert the notebooks to Markdown, and the resulting Markdown files are stored in the `pages/notebooks` directory. Additionally, an artifact named "notebooks" is uploaded using the `actions/upload-artifact` action, which allows for easy access to the converted Markdown files for debugging.