### PR TITLE
Update notebook conversion and GitHub Pages deployment

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -9,8 +9,9 @@ on:
     inputs:
       dry-run:
         description: 'Dry Run'
+        type: boolean
         required: false
-        default: 'true'
+        default: true
 
 jobs:
   run-notebooks:

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -28,7 +28,7 @@ jobs:
         pip install jekyllnb
 
     - name: Notebooks to Jekyl Markdown
-      run: jupyter jekyllnb --site-dir pages --page-dir pages/_pages --image-dir _pages/images --no-auto-folder notebooks/inflation.ipynb
+      run: jupyter jekyllnb --site-dir pages --page-dir pages/_pages --image-dir _pages/images --no-auto-folder notebooks/spx-and-tsla.ipynb
       #run: jupyter nbconvert --to=markdown --output-dir="./pages/notebooks" --debug notebooks/inflation.ipynb        
         # for notebook in notebooks/inflation.ipynb; do
         #  jupyter nbconvert --to=markdown --output-dir="./pages/notebooks" --debug "$notebook"
@@ -40,8 +40,11 @@ jobs:
         name: notebooks
         path: pages
 
+    # this action was designed to push commits to the gh-pages branch which would then be served by GitHub Pages
+    # i want to push the files in pages to the main branch to trigger the GitHub Pages deployment
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:
+        branch: main
         folder: pages
         dry-run: true

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -6,6 +6,11 @@ on:
     # - cron:  '0 21 * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry Run'
+        required: false
+        default: 'true'
 
 jobs:
   run-notebooks:
@@ -16,7 +21,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
         cache: 'pip'
@@ -28,7 +33,7 @@ jobs:
         pip install jekyllnb
 
     - name: Notebooks to Jekyl Markdown
-      run: jupyter jekyllnb --site-dir pages --page-dir pages/_pages --image-dir _pages/images --no-auto-folder notebooks/spx-and-tsla.ipynb
+      run: jupyter jekyllnb --site-dir pages --page-dir _pages --image-dir _pages/images --no-auto-folder notebooks/spx-and-tsla.ipynb
       #run: jupyter nbconvert --to=markdown --output-dir="./pages/notebooks" --debug notebooks/inflation.ipynb        
         # for notebook in notebooks/inflation.ipynb; do
         #  jupyter nbconvert --to=markdown --output-dir="./pages/notebooks" --debug "$notebook"
@@ -47,4 +52,4 @@ jobs:
       with:
         branch: main
         folder: pages
-        dry-run: true
+        dry-run: ${{ github.event.inputs.dry-run }}

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -27,7 +27,7 @@ jobs:
         pip install -r src/requirements.txt
         pip install jekyllnb
 
-    - name: Convert notebooks to Markdown
+    - name: Notebooks to Jekyl Markdown
       run: jupyter jekyllnb --site-dir pages --page-dir pages/_pages --image-dir _pages/images --no-auto-folder notebooks/inflation.ipynb
       #run: jupyter nbconvert --to=markdown --output-dir="./pages/notebooks" --debug notebooks/inflation.ipynb        
         # for notebook in notebooks/inflation.ipynb; do
@@ -39,3 +39,9 @@ jobs:
       with:
         name: notebooks
         path: pages
+
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: pages
+        dry-run: true

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -25,11 +25,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r src/requirements.txt
-        pip install notebook
-        pip install nbconvert
+        pip install jekyllnb
 
     - name: Convert notebooks to Markdown
-      run: jupyter nbconvert --to=markdown --output-dir="./pages/notebooks" --debug notebooks/inflation.ipynb        
+      run: jupyter jekyllnb --site-dir pages --page-dir pages/_pages --image-dir _pages/images --no-auto-folder notebooks/inflation.ipynb
+      #run: jupyter nbconvert --to=markdown --output-dir="./pages/notebooks" --debug notebooks/inflation.ipynb        
         # for notebook in notebooks/inflation.ipynb; do
         #  jupyter nbconvert --to=markdown --output-dir="./pages/notebooks" --debug "$notebook"
         # done        
@@ -38,4 +38,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: notebooks
-        path: pages/notebooks/
+        path: pages


### PR DESCRIPTION
This pull request updates the notebook conversion process to use jekyllnb instead of nbconvert. It also adds GitHub Pages deployment for the converted notebooks. Additionally, a dry-run runtime variable has been added to the workflow.