### PR TITLE
Update delete_squashed_branch.sh script

### DIFF
--- a/.github/delete_squashed_branch.sh
+++ b/.github/delete_squashed_branch.sh
@@ -1,5 +1,5 @@
 #https://stackoverflow.com/questions/41946475/git-why-cant-i-delete-my-branch-after-a-squash-merge
 git checkout main
-git fetch
+git fetch -p
 git pull
 git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base main $branch) && [[ $(git cherry main $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done


### PR DESCRIPTION
This PR updates the delete_squashed_branch.sh script by adding the "-p" flag to the "git fetch" command. This ensures that any remote branches that have been deleted are also removed locally.