### PR TITLE
Update Jupyter notebook conversion command

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -44,7 +44,7 @@ jobs:
         pip install -r src/requirements.txt  
 
     - name: Notebooks to Jekyl Markdown
-      run: jupyter nbconvert --config notebooks/nbconvert_cfg.py --to markdown notebooks/spx-and-tsla.ipynb
+      run: jupyter nbconvert --config notebooks/nbconvert_cfg.py --to markdown notebooks/*.ipynb
 
     - name: Commit changes
       uses: actions-x/commit@v6        


### PR DESCRIPTION
This pull request updates the Jupyter notebook conversion command in the refresh-data workflow to convert all notebooks in the notebooks directory to markdown, instead of converting only spx-and-tsla.ipynb. This ensures that all notebooks are properly converted and included in the markdown files.