### PR TITLE
Add GitHub Action workflows

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,8 +1,8 @@
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy to GitHub Pages
+name: Deploy Pages
+
+# If pages files change, generate and publish jekyl pages to github
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
     paths:

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,4 +1,9 @@
-name: Publish Jupyter Notebooks
+name: Notebook Pages
+
+# On schedule run the notebooks to refresh the data and generate pages
+# If src or notebooks are updated, run the notebooks to generate pages
+# If project or execution time grows then change flow to 
+# only run the notebooks that changed or if their associated data has changed.
 
 on:
   #schedule:
@@ -54,5 +59,6 @@ jobs:
 
     - name: Commit changes
       uses: stefanzweifel/git-auto-commit-action@v5
+      if: github.event_name == 'pull_request'
       with:
         branch: ${{ github.head_ref }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Python
 on:
   push:
     branches:

--- a/.github/workflows/readme.md
+++ b/.github/workflows/readme.md
@@ -1,0 +1,33 @@
+# Github Action Workflows
+
+Workflows can be triggered when files in a directory change, but cannot conditionally run different individual steps depending upon which files changed. There are marketplace extensions that can add some filter functionality.
+
+Initial workflows are created per directory so that they only run when needed.
+
+``` mermaid
+graph LR;
+    src-->notebook;
+    notebook<-. refresh .->data;
+    notebook-->pages
+    pages-->gh-pages
+```
+
+## Python Modules
+
+I have reusable python code in modules that can be imported to all my notebooks. The reusable python code is in `/src` directory and I have also created unit tests and sonar code quality scans for these files.
+
+I only need to run these tests when the `/src` files change.
+
+## Jupyter Notebooks
+
+I have Jupyter notebooks that consume the Python modules and generate data tables and charts.
+
+I need to run the notebooks when the `/notebook` files or the `/src` files change.
+
+The Jupyter notebooks also download and refresh data when needed so I also need to run these notebooks on regular schedule, some quarterly, some at least monthly.
+
+## Github Pages
+
+I convert the Jupyter Notebooks and static `/pages` files to Jekyl format and publish them to Github Pages.
+
+I need to publish Github pages when the data changes, or when the static `/pages` change, or when the `/notebooks` change.


### PR DESCRIPTION
This pull request adds GitHub Action workflows for deploying pages, running notebooks, testing Python code, and publishing GitHub Pages. The workflows are triggered based on changes to specific directories and files.