### PR TITLE
Revise markdown text in inflation.ipynb

### DIFF
--- a/notebooks/inflation.ipynb
+++ b/notebooks/inflation.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 451,
+   "execution_count": 1,
    "id": "d3822f4f-c72b-4641-b25b-12407a527dc2",
    "metadata": {},
    "outputs": [],
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 452,
+   "execution_count": 2,
    "id": "378bb8c6-86df-4fc0-b8bf-e042e1ffd52b",
    "metadata": {},
    "outputs": [],
@@ -53,7 +53,7 @@
     "\"\"\" Load data \n",
     "RBA Inflation Rate (Consumer Price Index) is released quarterly, \n",
     "and the monthly CPI 'indicator' that includes 2/3rds of the CPI basket is released monthly.\n",
-    "Q3 2023 was published on last thursday of month Thu 26 Oct 2023. Q4 should be expected Thu 25 Jan 2024 but not published on Thu 25 or 26 (public holiday) 27 Sat.\n",
+    "Q3 2023 was published on last thursday of month Thu 26 Oct 2023. Q4 should be expected Thu 25 Jan 2024 but not published on Thu 25 or 26 (public holiday) 27 Sat, 28 or 29.\n",
     "\"\"\"\n",
     "# RBA quarterly inflation rates from 1922\n",
     "# Rates are published in the month after the quarter ends.\n",
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 453,
+   "execution_count": 3,
    "id": "54fa8948",
    "metadata": {},
    "outputs": [],
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 454,
+   "execution_count": 4,
    "id": "4d37f552-f01f-4419-b2c6-d21eb39e5152",
    "metadata": {},
    "outputs": [],
@@ -119,12 +119,12 @@
    "source": [
     "Inflation rocketed through the roof in the 1970s peaking at 18% in 1975. \n",
     "\n",
-    "Inflation remained highly volatile but eventually stabilized through the 1990s and has been trending slightly down until the sharp rise in 2021."
+    "Inflation remained highly volatile but eventually stabilized through the 1990s, and was trending slightly down until the spike back up to 8% at the end of 2022."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 455,
+   "execution_count": 5,
    "id": "60cfc471",
    "metadata": {},
    "outputs": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 456,
+   "execution_count": 6,
    "id": "182add13",
    "metadata": {},
    "outputs": [],
@@ -199,12 +199,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 457,
+   "execution_count": 7,
    "id": "22ce9f85",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\" Create a markdown data table of the multi year percentiles\"\"\"\n",
+    "\"\"\" Create a markdown data table of the multi year percentiles to reuse in other notebooks \"\"\"\n",
     "\n",
     "# Create the header rows of the table\n",
     "table = \"| Years |   \" + \" |   \".join(f'{str(percentile)}' for percentile in percentiles) + \" |\\n\"\n",
@@ -219,67 +219,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 458,
+   "execution_count": 8,
    "id": "876a5805",
    "metadata": {},
    "outputs": [],
    "source": [
     "with open('../data/inflation_percentiles.md', 'w') as f:\n",
-    "    f.write(table)"
+    "    f.write(table)\n",
+    "    f.close()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 459,
-   "id": "9767647d",
+   "execution_count": 9,
+   "id": "a1117e80",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/markdown": [
-       "\n",
-       "Calculating the 25th and 75th percentile over a 10 year time horizon helps visualize the lower and upper long term trends.\n",
-       "\n",
-       "Over the last 10 years the median (50th percetile) change is 1.90%.\n",
-       "\n",
-       "Over the last 30 years the median (50th percetile) change is 2.40%.\n",
-       "\n",
-       "| Years | 25th percentile | 50th percentile | 75th percentile |\n",
-       "|-------|-----:|-----:|-----:|\n",
-       "| 1     | 5.85 | 6.50 | 7.20 |\n",
-       "| 10    | 1.50 | 1.90 | 3.00 |\n",
-       "| 30    | 1.70 | 2.40 | 3.12 |\n",
-       "\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "ename": "SyntaxError",
+     "evalue": "incomplete input (135595323.py, line 3)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Cell \u001b[0;32mIn[9], line 3\u001b[0;36m\u001b[0m\n\u001b[0;31m    \"\"\")\u001b[0m\n\u001b[0m        ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m incomplete input\n"
+     ]
     }
    ],
    "source": [
-    "# Replace headings for percentile column headings\n",
-    "headings = table.split('\\n')[0].split('|')[2:-1]\n",
-    "updated_headings = [ heading.strip() + 'th percentile' for heading in headings]\n",
-    "updated_headings_row = '| Years | ' + ' | '.join(updated_headings) + ' |'\n",
-    "show_table = table.replace(table.split('\\n')[0], updated_headings_row, 1)\n",
-    "\n",
     "display(Markdown(f\"\"\"\n",
     "Calculating the {percentiles[0]}th and {percentiles[2]}th percentile over a {multi_year} year time horizon helps visualize the {Percentiles._fields[0]} and {Percentiles._fields[2]} long term trends.\n",
-    "\n",
-    "Over the last {multi_year} years the {Percentiles._fields[1]} ({percentiles[1]}th percetile) change is { \"{:,.2f}\".format(df_inflation[f'rolling_{multi_year}_years_{Percentiles._fields[1]}'].iloc[-1])  }%.\n",
-    "\n",
-    "Over the last {multi_year * multi_year_extended} years the {Percentiles._fields[1]} ({percentiles[1]}th percetile) change is { \"{:,.2f}\".format(df_inflation[f'rolling_{multi_year * multi_year_extended}_years_{Percentiles._fields[1]}'].iloc[-1])  }%.\n",
-    "\n",
-    "{show_table}\n",
-    "\"\"\"))"
+    "\"\"\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 460,
+   "execution_count": null,
    "id": "4c5b6f4d",
    "metadata": {},
    "outputs": [],
@@ -331,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 461,
+   "execution_count": null,
    "id": "cb255e3b",
    "metadata": {},
    "outputs": [
@@ -360,15 +333,59 @@
     }
    ],
    "source": [
-    "display(Markdown(\"\"\"\n",
-    "The chart shows inflation stayed close to the RBA target inflation rate of 2 to 3 percent for over twenty five years.\n",
-    "\"\"\"))\n",
     "plot_percentiles(df_inflation, percentiles, multi_year)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 462,
+   "execution_count": null,
+   "id": "e79cc3c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "\n",
+       "Calculating the 25th and 75th percentile over a 10 year time horizon helps visualize the lower and upper long term trends.\n",
+       "\n",
+       "Over the last 10 years the median (50th percetile) change is 1.90%.\n",
+       "\n",
+       "Over the last 30 years the median (50th percetile) change is 2.40%.\n",
+       "\n",
+       "| Years | 25th percentile | 50th percentile | 75th percentile |\n",
+       "|-------|-----:|-----:|-----:|\n",
+       "| 1     | 5.85 | 6.50 | 7.20 |\n",
+       "| 10    | 1.50 | 1.90 | 3.00 |\n",
+       "| 30    | 1.70 | 2.40 | 3.12 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Replace headings for percentile column headings\n",
+    "headings = table.split('\\n')[0].split('|')[2:-1]\n",
+    "updated_headings = [ heading.strip() + 'th percentile' for heading in headings]\n",
+    "updated_headings_row = '| Years | ' + ' | '.join(updated_headings) + ' |'\n",
+    "show_table = table.replace(table.split('\\n')[0], updated_headings_row, 1)\n",
+    "\n",
+    "display(Markdown(f\"\"\"\n",
+    "Over the last {multi_year} years the {Percentiles._fields[1]} ({percentiles[1]}th percetile) change is { \"{:,.2f}\".format(df_inflation[f'rolling_{multi_year}_years_{Percentiles._fields[1]}'].iloc[-1])  }%.\n",
+    "\n",
+    "Over the last {multi_year * multi_year_extended} years the {Percentiles._fields[1]} ({percentiles[1]}th percetile) change is { \"{:,.2f}\".format(df_inflation[f'rolling_{multi_year * multi_year_extended}_years_{Percentiles._fields[1]}'].iloc[-1])  }%.\n",
+    "\n",
+    "{show_table}\n",
+    "\"\"\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "866e3dd1",
    "metadata": {},
    "outputs": [
@@ -405,10 +422,6 @@
     "bottom_limit = -1\n",
     "legend_location = 'upper center'\n",
     "\n",
-    "display(Markdown(\"\"\"\n",
-    "Same data plotted from 1995.\n",
-    "\"\"\"))\n",
-    "\n",
     "plot_percentiles(df_inflation, percentiles, multi_year)"
    ]
   },
@@ -417,12 +430,14 @@
    "id": "6183fcbf",
    "metadata": {},
    "source": [
+    "The chart shows inflation stayed close to the RBA target inflation rate of 2 to 3 percent for over twenty five years.\n",
+    "\n",
     "> ℹ The data suggests reasonable confidence using a baseline inflation of 2% to 2.5% with some uncertainty or risk that inflation could peak higher."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 463,
+   "execution_count": null,
    "id": "522a6fb0",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
This pull request revises the markdown text in the inflation.ipynb notebook. It updates the description of inflation trends and adds a markdown data table of multi-year percentiles. The changes improve the clarity and accuracy of the information presented in the notebook.