### PR TITLE
Add cache dependency path for pip cache

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -26,6 +26,7 @@ jobs:
       with:
         python-version: 3.11
         cache: 'pip'
+        cache-dependency-path: '**/requirements*.txt'
 
     - name: Install dependencies
       run: |

--- a/pages/tsla-prices.md
+++ b/pages/tsla-prices.md
@@ -24,7 +24,7 @@ Over the last 10 years the median change is 19.03%:
     
 
 
-    /tmp/ipykernel_1931/113867765.py:10: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
+    /tmp/ipykernel_1958/113867765.py:10: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
       dfTargets = dfTargets.applymap(lambda x: x.strip() if isinstance(x, str) else x)
 
 

--- a/pages/tsla-yoy.md
+++ b/pages/tsla-yoy.md
@@ -199,19 +199,19 @@
     
 
 
-    /tmp/ipykernel_1939/1678989774.py:10: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
+    /tmp/ipykernel_1982/1678989774.py:10: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
       dfTargets = dfTargets.applymap(lambda x: x.strip() if isinstance(x, str) else x)
 
 
-    /tmp/ipykernel_1939/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
+    /tmp/ipykernel_1982/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
       subgroup['BearChange'] = subgroup['Bear'].pct_change() * 100 # change since previous row
-    /tmp/ipykernel_1939/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
+    /tmp/ipykernel_1982/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
       subgroup['BearChange'] = subgroup['Bear'].pct_change() * 100 # change since previous row
-    /tmp/ipykernel_1939/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
+    /tmp/ipykernel_1982/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
       subgroup['BearChange'] = subgroup['Bear'].pct_change() * 100 # change since previous row
-    /tmp/ipykernel_1939/3110887510.py:10: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
+    /tmp/ipykernel_1982/3110887510.py:10: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
       subgroup['BaseChange'] = subgroup['Base'].pct_change() * 100 # change since previous row
-    /tmp/ipykernel_1939/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
+    /tmp/ipykernel_1982/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
       subgroup['BearChange'] = subgroup['Bear'].pct_change() * 100 # change since previous row
 
 
@@ -386,13 +386,13 @@
 
 
 
-    /tmp/ipykernel_1939/3440364386.py:58: SettingWithCopyWarning: 
+    /tmp/ipykernel_1982/3440364386.py:58: SettingWithCopyWarning: 
     A value is trying to be set on a copy of a slice from a DataFrame.
     Try using .loc[row_indexer,col_indexer] = value instead
     
     See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
       rolling_forecast['BearChange'] = rolling_forecast['Bear'].pct_change() * 100 # change since previous row
-    /tmp/ipykernel_1939/3440364386.py:61: SettingWithCopyWarning: 
+    /tmp/ipykernel_1982/3440364386.py:61: SettingWithCopyWarning: 
     A value is trying to be set on a copy of a slice from a DataFrame.
     Try using .loc[row_indexer,col_indexer] = value instead
     


### PR DESCRIPTION
This pull request adds a cache dependency path for the pip cache. This allows for more efficient caching of dependencies by including all requirements files in the cache.