### PR TITLE
Add redirect for S&P 500 page

### DIFF
--- a/notebooks/spx-prices.ipynb
+++ b/notebooks/spx-prices.ipynb
@@ -8,7 +8,9 @@
     "---\n",
     "layout: page\n",
     "title: S&P 500\n",
+    "# override link to avoid '&' char in the url\n",
     "permalink: spx\n",
+    "redirect_from: \"/spx.md\"\n",
     "---"
    ]
   },

--- a/pages/_config.yml
+++ b/pages/_config.yml
@@ -13,6 +13,7 @@ plugins:
   # minima theme was designed with jekyll-feed to create rss feed of blog posts
   #- jekyll-feed
   # NOTE: add custom _includes/footer.html to remove the rss 'subscribe' link
+  - jekyll-redirect-from
   
 header_pages:
   - retirement-planning.md

--- a/pages/spx-prices.md
+++ b/pages/spx-prices.md
@@ -1,7 +1,9 @@
 ---
 layout: page
 title: S&P 500
+# override link to avoid '&' char in the url
 permalink: spx
+redirect_from: "/spx.md"
 ---
 
 The S&P 500 Index from Standard & Poor's is a market-capitalization-weighted index tracking the 500 largest publicly traded companies in the US. 

--- a/pages/tsla-prices.md
+++ b/pages/tsla-prices.md
@@ -24,7 +24,7 @@ Over the last 10 years the median change is 18.75%:
     
 
 
-    /tmp/ipykernel_2349/113867765.py:10: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
+    /tmp/ipykernel_2048/113867765.py:10: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
       dfTargets = dfTargets.applymap(lambda x: x.strip() if isinstance(x, str) else x)
 
 

--- a/pages/tsla-yoy.md
+++ b/pages/tsla-yoy.md
@@ -199,19 +199,19 @@
     
 
 
-    /tmp/ipykernel_2369/1678989774.py:10: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
+    /tmp/ipykernel_2068/1678989774.py:10: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
       dfTargets = dfTargets.applymap(lambda x: x.strip() if isinstance(x, str) else x)
 
 
-    /tmp/ipykernel_2369/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
+    /tmp/ipykernel_2068/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
       subgroup['BearChange'] = subgroup['Bear'].pct_change() * 100 # change since previous row
-    /tmp/ipykernel_2369/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
+    /tmp/ipykernel_2068/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
       subgroup['BearChange'] = subgroup['Bear'].pct_change() * 100 # change since previous row
-    /tmp/ipykernel_2369/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
+    /tmp/ipykernel_2068/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
       subgroup['BearChange'] = subgroup['Bear'].pct_change() * 100 # change since previous row
-    /tmp/ipykernel_2369/3110887510.py:10: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
+    /tmp/ipykernel_2068/3110887510.py:10: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
       subgroup['BaseChange'] = subgroup['Base'].pct_change() * 100 # change since previous row
-    /tmp/ipykernel_2369/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
+    /tmp/ipykernel_2068/3110887510.py:11: FutureWarning: The default fill_method='pad' in Series.pct_change is deprecated and will be removed in a future version. Either fill in any non-leading NA values prior to calling pct_change or specify 'fill_method=None' to not fill NA values.
       subgroup['BearChange'] = subgroup['Bear'].pct_change() * 100 # change since previous row
 
 
@@ -386,13 +386,13 @@
 
 
 
-    /tmp/ipykernel_2369/3440364386.py:58: SettingWithCopyWarning: 
+    /tmp/ipykernel_2068/3440364386.py:58: SettingWithCopyWarning: 
     A value is trying to be set on a copy of a slice from a DataFrame.
     Try using .loc[row_indexer,col_indexer] = value instead
     
     See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
       rolling_forecast['BearChange'] = rolling_forecast['Bear'].pct_change() * 100 # change since previous row
-    /tmp/ipykernel_2369/3440364386.py:61: SettingWithCopyWarning: 
+    /tmp/ipykernel_2068/3440364386.py:61: SettingWithCopyWarning: 
     A value is trying to be set on a copy of a slice from a DataFrame.
     Try using .loc[row_indexer,col_indexer] = value instead
     


### PR DESCRIPTION
This pull request adds a redirect for the S&P 500 page to avoid the use of the '&' character in the URL.