### PR TITLE
Update schedule for running notebooks

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -12,8 +12,9 @@ name: Notebook Pages
 on:
   schedule:
     # Runs every thursday after extended hours
-    # entended hours 4am-8pm EST = 9am-1am UTC next day
-    - cron:  '0 1 * * 5'
+    # entended hours 4am-8pm EST; 8pm = 1am UTC next day = 12pm AEST next day
+    #- cron:  '0 1 * * 5'
+    - cron:  '0 1 * * *'
 
   # Have to run notebooks on main branch to refresh cache data
   push:


### PR DESCRIPTION
This pull request updates the schedule for running notebooks. The previous schedule was set to run every Thursday after extended hours, but it has been changed to run every day at 1:00 AM UTC. This change ensures that the notebooks are refreshed regularly and the cache data is up to date.