### PR TITLE
Add .tmp and pages/images/*.png to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ source
 __pycache__/
 .coverage
 *.tmp
+pages/images/*.png


### PR DESCRIPTION
This pull request adds the .tmp and pages/images/*.png files to the .gitignore file. This ensures that these files are not tracked by Git and will not be included in future commits.