### PR TITLE
Set magic html tag on markdown cell

### DIFF
--- a/notebooks/tsla-and-targets.ipynb
+++ b/notebooks/tsla-and-targets.ipynb
@@ -261,7 +261,8 @@
    "id": "44ecdf56",
    "metadata": {},
    "source": [
-    "<div style=\"text-align: center; margin:auto;\"><a href=\"spx-prices.md\"><img src=\"images/spx-prices_5_0.png\" width=\"400\"/> <img src=\"images/spx-prices_7_0.png\" width=\"400\"/></a></div>"
+    "%%html\n",
+    "<div style=\"text-align: center;\"><a href=\"spx-prices.md\"><img src=\"images/spx-prices_5_0.png\" width=\"400\"/> <img src=\"images/spx-prices_7_0.png\" width=\"400\"/></a></div>"
    ]
   },
   {


### PR DESCRIPTION
This pull request adds a magic html tag to the markdown cell in order to center the images displayed in the cell.