### PR TITLE
Update links to inflation and interest rate pages

### DIFF
--- a/notebooks/inflation-and-interest-rates.ipynb
+++ b/notebooks/inflation-and-interest-rates.ipynb
@@ -43,17 +43,17 @@
    "id": "5f68b363",
    "metadata": {},
    "source": [
-    "## Inflation\n",
+    "## [Inflation](inflation.html)\n",
     "\n",
     "The Consumer Price Index that the Reserve Bank of Australia use to index inflation is published quarterly, one month after the end of each quarter.\n",
     "\n",
-    "See [inflation](inflation.ipynb) for inflation charts, trends and analysis.\n",
+    "See [inflation](inflation.html) for inflation charts, trends and analysis.\n",
     "\n",
-    "## Interest Rates\n",
+    "## [Interest Rates](interest-rates.html)\n",
     "\n",
     "The Housing Loan Lending Rates are set by the Reserve Bank of Australia and published monthly within five business days after month end.\n",
     "\n",
-    "See [interest rates](interest-rates.ipynb) for interest rate charts, trends and analysis.\n",
+    "See [interest rates](interest-rates.html) for interest rate charts, trends and analysis.\n",
     "\n",
     "## Inflation and Interest Rates"
    ]
@@ -136,11 +136,15 @@
    "id": "98a0afe2",
    "metadata": {},
    "source": [
-    "The Reserve Bank of Australia has often increased base interest rates aledging a high correlation between interest rates and inflation.\n",
+    "The Reserve Bank of Australia has often increased base interest rates alledging a high correlation between interest rates and inflation.\n",
     "\n",
-    "This appears a reasonable construct from basic supply and demand economics; when households have high disposable income, demand for non-essential goods and services increases, and prices increase to meet demand, resulting in inflation. Increasing interest rates reduces the disposable income for those with high debt, reduces demand, resulting in reduced inflation.\n",
+    "This appears a reasonable construct from basic supply and demand economics; when households have high disposable income, demand for non-essential goods and services increases, and if supply is limited, prices increase to meet demand, resulting in inflation. \n",
     "\n",
-    "Is there really a high correlation, or is this over simplification? Perhaps there are other external factors influencing inflation, such as global oil prices, foreign war, pandemic supply chains, that have nothing to do with household disposable income?"
+    "Increasing interest rates reduces disposable income (for those with borrowing debt), thus reducing some demand for non-essential goods and services, potentially resulting in some price reductions, and subsequently reducing inflation.\n",
+    "\n",
+    "Is there really a high correlation, or is this over simplification? Do lower interest rates subsequently cause inflation to rise, and higher interest rates subsequently cause inflation to reduce?\n",
+    "\n",
+    "Perhaps there are other external factors influencing inflation, such as global oil prices, foreign war, pandemic supply chains, that have nothing to do with household disposable income?"
    ]
   },
   {

--- a/pages/index.md
+++ b/pages/index.md
@@ -7,9 +7,11 @@ This project was created to provide some guidelines and forecasts for the follow
 ## Content
 
 - [Retirement Planning](retirement-planning.md)
-- [Inflation](inflation.md)
-- [Interest Rates](interest-rates.md)
+
 - [Inflation and Interest Rates](inflation-and-interest-rates.md)
+    - [Inflation](inflation.md)
+    - [Interest Rates](interest-rates.md)
+
 - [S&P 500 Index](spx-prices.md)
 - [Tesla (TSLA)](tsla-prices.md)
 


### PR DESCRIPTION
This pull request updates the links to the inflation and interest rate pages in the notebooks and index.md files. The links now point to the correct pages (inflation.html and interest-rates.html) instead of the incorrect pages (inflation.ipynb and interest-rates.ipynb). This ensures that users can access the correct information and analysis for inflation and interest rates.