### PR TITLE
Fix file cleanup in update_file function

### DIFF
--- a/pages/test.md
+++ b/pages/test.md
@@ -10,8 +10,8 @@ title: Notebook Test
 
 
 
-    Publish date: 2024-04-13 23:32:53
-    1713015173.664147
+    Publish date: 2024-04-13 23:43:03
+    1713015783.050923
     ../data/spx_HistoricalData.csv
     1713611640.5575867
     is_stale_file: False

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -109,6 +109,8 @@ def update_file(local_file, csv_url):
     urllib.request.urlretrieve(csv_url, temp_file) 
     if (not os.path.exists(local_file)) or (get_file_hash(temp_file) != get_file_hash(local_file)):
         os.replace(temp_file, local_file)
+    else:
+        os.remove(temp_file)
 
 def get_quarter_publish_date(quarter):
     """


### PR DESCRIPTION
This pull request fixes the file cleanup issue in the update_file function. Previously, the temporary file was not being removed if the local file already existed and had the same hash. This PR adds a check to remove the temporary file in such cases.