### PR TITLE
Display percentile table without markdown conversion

### DIFF
--- a/notebooks/inflation.ipynb
+++ b/notebooks/inflation.ipynb
@@ -256,26 +256,72 @@
     },
     {
      "data": {
-      "text/markdown": [
-       "|   Years |   25th percentile |   50th percentile |   75th percentile |\n",
-       "|--------:|------------------:|------------------:|------------------:|\n",
-       "|       1 |              5.08 |              5.7  |              6.25 |\n",
-       "|       5 |              1.53 |              3.25 |              5.55 |\n",
-       "|      10 |              1.5  |              1.9  |              3.12 |\n",
-       "|      20 |              1.77 |              2.4  |              3.15 |\n",
-       "|      30 |              1.7  |              2.45 |              3.23 |"
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_4ec0b\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_4ec0b_level0_col0\" class=\"col_heading level0 col0\" >25th percentile</th>\n",
+       "      <th id=\"T_4ec0b_level0_col1\" class=\"col_heading level0 col1\" >50th percentile</th>\n",
+       "      <th id=\"T_4ec0b_level0_col2\" class=\"col_heading level0 col2\" >75th percentile</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th class=\"index_name level0\" >Years</th>\n",
+       "      <th class=\"blank col0\" >&nbsp;</th>\n",
+       "      <th class=\"blank col1\" >&nbsp;</th>\n",
+       "      <th class=\"blank col2\" >&nbsp;</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4ec0b_level0_row0\" class=\"row_heading level0 row0\" >1</th>\n",
+       "      <td id=\"T_4ec0b_row0_col0\" class=\"data row0 col0\" >5.08</td>\n",
+       "      <td id=\"T_4ec0b_row0_col1\" class=\"data row0 col1\" >5.70</td>\n",
+       "      <td id=\"T_4ec0b_row0_col2\" class=\"data row0 col2\" >6.25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4ec0b_level0_row1\" class=\"row_heading level0 row1\" >5</th>\n",
+       "      <td id=\"T_4ec0b_row1_col0\" class=\"data row1 col0\" >1.53</td>\n",
+       "      <td id=\"T_4ec0b_row1_col1\" class=\"data row1 col1\" >3.25</td>\n",
+       "      <td id=\"T_4ec0b_row1_col2\" class=\"data row1 col2\" >5.55</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4ec0b_level0_row2\" class=\"row_heading level0 row2\" >10</th>\n",
+       "      <td id=\"T_4ec0b_row2_col0\" class=\"data row2 col0\" >1.50</td>\n",
+       "      <td id=\"T_4ec0b_row2_col1\" class=\"data row2 col1\" >1.90</td>\n",
+       "      <td id=\"T_4ec0b_row2_col2\" class=\"data row2 col2\" >3.12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4ec0b_level0_row3\" class=\"row_heading level0 row3\" >20</th>\n",
+       "      <td id=\"T_4ec0b_row3_col0\" class=\"data row3 col0\" >1.77</td>\n",
+       "      <td id=\"T_4ec0b_row3_col1\" class=\"data row3 col1\" >2.40</td>\n",
+       "      <td id=\"T_4ec0b_row3_col2\" class=\"data row3 col2\" >3.15</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_4ec0b_level0_row4\" class=\"row_heading level0 row4\" >30</th>\n",
+       "      <td id=\"T_4ec0b_row4_col0\" class=\"data row4 col0\" >1.70</td>\n",
+       "      <td id=\"T_4ec0b_row4_col1\" class=\"data row4 col1\" >2.45</td>\n",
+       "      <td id=\"T_4ec0b_row4_col2\" class=\"data row4 col2\" >3.23</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "<pandas.io.formats.style.Styler at 0x7fd312dbfc50>"
       ]
      },
+     "execution_count": 9,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "percentiles.display_percentile_summary(df_last_percentiles, 'inflation rate')\n",
-    "percentiles.display_dataframe_table(df_last_percentiles)"
+    "#percentiles.display_dataframe_table(df_last_percentiles)\n",
+    "display = df_last_percentiles.style.format('{0:.2f}')\n",
+    "display"
    ]
   },
   {

--- a/pages/inflation.md
+++ b/pages/inflation.md
@@ -36,13 +36,60 @@ Over the last 30 years the median (50th percetile) inflation rate is 2.45%.
 
 
 
-|   Years |   25th percentile |   50th percentile |   75th percentile |
-|--------:|------------------:|------------------:|------------------:|
-|       1 |              5.08 |              5.7  |              6.25 |
-|       5 |              1.53 |              3.25 |              5.55 |
-|      10 |              1.5  |              1.9  |              3.12 |
-|      20 |              1.77 |              2.4  |              3.15 |
-|      30 |              1.7  |              2.45 |              3.23 |
+
+
+<style type="text/css">
+</style>
+<table id="T_dfdab">
+  <thead>
+    <tr>
+      <th class="blank level0" >&nbsp;</th>
+      <th id="T_dfdab_level0_col0" class="col_heading level0 col0" >25th percentile</th>
+      <th id="T_dfdab_level0_col1" class="col_heading level0 col1" >50th percentile</th>
+      <th id="T_dfdab_level0_col2" class="col_heading level0 col2" >75th percentile</th>
+    </tr>
+    <tr>
+      <th class="index_name level0" >Years</th>
+      <th class="blank col0" >&nbsp;</th>
+      <th class="blank col1" >&nbsp;</th>
+      <th class="blank col2" >&nbsp;</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th id="T_dfdab_level0_row0" class="row_heading level0 row0" >1</th>
+      <td id="T_dfdab_row0_col0" class="data row0 col0" >5.08</td>
+      <td id="T_dfdab_row0_col1" class="data row0 col1" >5.70</td>
+      <td id="T_dfdab_row0_col2" class="data row0 col2" >6.25</td>
+    </tr>
+    <tr>
+      <th id="T_dfdab_level0_row1" class="row_heading level0 row1" >5</th>
+      <td id="T_dfdab_row1_col0" class="data row1 col0" >1.53</td>
+      <td id="T_dfdab_row1_col1" class="data row1 col1" >3.25</td>
+      <td id="T_dfdab_row1_col2" class="data row1 col2" >5.55</td>
+    </tr>
+    <tr>
+      <th id="T_dfdab_level0_row2" class="row_heading level0 row2" >10</th>
+      <td id="T_dfdab_row2_col0" class="data row2 col0" >1.50</td>
+      <td id="T_dfdab_row2_col1" class="data row2 col1" >1.90</td>
+      <td id="T_dfdab_row2_col2" class="data row2 col2" >3.12</td>
+    </tr>
+    <tr>
+      <th id="T_dfdab_level0_row3" class="row_heading level0 row3" >20</th>
+      <td id="T_dfdab_row3_col0" class="data row3 col0" >1.77</td>
+      <td id="T_dfdab_row3_col1" class="data row3 col1" >2.40</td>
+      <td id="T_dfdab_row3_col2" class="data row3 col2" >3.15</td>
+    </tr>
+    <tr>
+      <th id="T_dfdab_level0_row4" class="row_heading level0 row4" >30</th>
+      <td id="T_dfdab_row4_col0" class="data row4 col0" >1.70</td>
+      <td id="T_dfdab_row4_col1" class="data row4 col1" >2.45</td>
+      <td id="T_dfdab_row4_col2" class="data row4 col2" >3.23</td>
+    </tr>
+  </tbody>
+</table>
+
+
 
 
 

--- a/pages/test.md
+++ b/pages/test.md
@@ -10,8 +10,8 @@ title: Notebook Test
 
 
 
-    Publish date: 2024-04-17 22:01:57
-    1713355317.41749
+    Publish date: 2024-04-17 23:12:40
+    1713359560.670615
     ../data/spx_HistoricalData.csv
     1713611640.5575867
     is_stale_file: False

--- a/src/data_functions.py
+++ b/src/data_functions.py
@@ -45,7 +45,7 @@ class Percentiles:
             df_tail = df.tail(rows)
             data = {}
             for percentile in  self.percentiles:
-                data[f"{percentile}th percentile"] = "{:.2f}".format(df_tail[self.data_column].quantile(percentile/100))
+                data[f"{percentile}th percentile"] = df_tail[self.data_column].quantile(percentile/100)
             df_temp = pd.DataFrame(data, index=[years])
             df_last_percentiles = pd.concat([df_last_percentiles, df_temp])
         df_last_percentiles.index.name = 'Years'
@@ -58,6 +58,8 @@ class Percentiles:
 #       f.close()
 
     def display_dataframe_table(self, df):
+        df.style.format(precision=2)
+        df.tail(10)
         markdown_table = df.to_markdown()
         display(Markdown(markdown_table))
 


### PR DESCRIPTION
This pull request updates the display of the percentile table to show the data without markdown conversion. It also formats the table with two decimal places and displays only the last 10 rows.