### PR TITLE
Fix chart links

### DIFF
--- a/notebooks/tsla-targets.ipynb
+++ b/notebooks/tsla-targets.ipynb
@@ -273,7 +273,7 @@
    "id": "44ecdf56",
    "metadata": {},
    "source": [
-    "<a href=\"spx.md\" style=\"text-align: center; display: block\"><img src=\"images/spx_5_0.png\" width=\"400\"/> <img src=\"images/spx_7_0.png\" width=\"400\"/></a>"
+    "<a href=\"spx.html\" style=\"text-align: center; display: block\"><img src=\"images/spx_5_0.png\" width=\"400\"/> <img src=\"images/spx_7_0.png\" width=\"400\"/></a>"
    ]
   },
   {


### PR DESCRIPTION
This pull request fixes the chart links in the project. Previously, the links were pointing to an incorrect file extension (spx.md) instead of the correct one (spx.html). This PR updates the links to use the correct file extension.