### PR TITLE
Temporarily disable cache

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -68,12 +68,12 @@ jobs:
         ls -al ./data        
         cat data/hash.txt
 
-    - name: Cache Data
-      uses: actions/cache@v4
-      with:
-        path: data/**
-        key: data-${{ hashFiles('data/hash.txt') }}
-        restore-keys: data-
+#    - name: Cache Data
+#      uses: actions/cache@v4
+#      with:
+#        path: data/**
+#        key: data-${{ hashFiles('data/hash.txt') }}
+#        restore-keys: data-
 
     - name: Run Standalone Notebooks
       # run standalone notebooks first (no hyphen in name), then ! *-and- notebooks, then *-and-* notebooks


### PR DESCRIPTION
This pull request temporarily disables the caching of data in the workflow. The `Cache Data` step in the workflow has been commented out to prevent caching. This change is necessary to troubleshoot an issue related to the caching mechanism.