### PR TITLE
✅ Only trigger on successful workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,6 +31,7 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Modify the workflow configuration to ensure that the deployment job only triggers if the preceding workflow completes successfully.