### PR TITLE
🔡 Fix Jekyll layout issues

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,7 +31,7 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/pages/_includes/sub-footer.html
+++ b/pages/_includes/sub-footer.html
@@ -1,0 +1,4 @@
+{% comment %}
+  Use this to insert markup before the closing body tag.
+  For example, scripts that need to be executed after the document has finished loading.
+{% endcomment %}


### PR DESCRIPTION
Adjust the workflow condition for the build job and add a comment for inserting markup before the closing body tag in the layout.