### PR TITLE
Separate notebook artifacts output directory

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -46,10 +46,11 @@ jobs:
             echo "run_id=$run_id" >> $GITHUB_ENV
           fi
       - name: Download Pages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           run-id: ${{ env.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: pages
 
       - name: Setup Pages
         uses: actions/configure-pages@v4      

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -98,7 +98,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: pages
-        path: pages
+        path: artifacts
 
     - name: Hash Data
       # Update hash of data files so we force new cache when data changes

--- a/data/hash.txt
+++ b/data/hash.txt
@@ -1,5 +1,5 @@
 89a65ffd68f1a1147a11210b567267cb  data/asfa-retirement-standard.md
-16cee4681cfb7b9941b8cb72d4b7871d  data/f5-data.csv
+9dbf05533874d12848fb13bb9ce65314  data/f5-data.csv
 a3808c063ab3acab427efb02f453623d  data/g1-data.csv
 907e04e7053b30feeaf73032d1741a1c  data/spx_HistoricalData_1940.csv
 16fa747c7d1f89e49cb41bdf94f0b3bf  data/spx_HistoricalData_1950.csv
@@ -14,15 +14,15 @@ dd18c45d4e07d598995a2eb815817194  data/spx_HistoricalData_2021.csv
 172c054b960060cc6b970ff063bf3216  data/spx_HistoricalData_2022.csv
 2a56d6722eb11883f3e390caae8122d2  data/spx_HistoricalData_2023.csv
 303dec23be37c93529933bdb49872e4d  data/spx_HistoricalData_2024.csv
-ba6ff876077329295da0b0858e5c6bae  data/spx_HistoricalData_2025.csv
+e21d6b721ac45cbb724bade28d9427e4  data/spx_HistoricalData_2025.csv
 d1ae9f54f14e0f4c7dc841269d65026b  data/tsla_HistoricalData_2010.csv
 23d946417cc7993e39c8315527a15379  data/tsla_HistoricalData_2020.csv
 a51de65bc4f2099dca4807ffd8bd6ee1  data/tsla_HistoricalData_2021.csv
 b6dfeea625b5766eff85aded9088327f  data/tsla_HistoricalData_2022.csv
-03e6abc232e58b1d83aa0b175ae04cf3  data/tsla_HistoricalData_2023.csv
-c2f19230a071b024c314a40c97574acc  data/tsla_HistoricalData_2024.csv
-8fa7c0233dd2abbb7e90023c64330213  data/tsla_HistoricalData_2025.csv
+0301c3361b9ad876bf76ed33a4a345fb  data/tsla_HistoricalData_2023.csv
+256f9cedef22251250bd7f7bfaf5064c  data/tsla_HistoricalData_2024.csv
+b5ec5da270b1f5dd7cda2b26dc4f3973  data/tsla_HistoricalData_2025.csv
 492b14b5f19f8a237e0769603e294d7f  data/tsla_PriceTarget_CernBasher.md
 afe6474cc29cba71307e82729f1923b6  data/tsla_PriceTarget_InvestAnswers.md
 9f6bf0a94ce6f7590e4d8021607a4503  data/tsla_PriceTarget_InvestAnswers_2024.md
-c89f3e437c86211d53da9d7380392c29  data/tsla_PriceTargets.md
+4170daeb361bfc6d14126a99638a9c71  data/tsla_PriceTargets.md

--- a/notebooks/nbconvert_cfg.py
+++ b/notebooks/nbconvert_cfg.py
@@ -2,7 +2,7 @@ c = get_config()
 # hide the code input (but include the chart image output)
 c.MarkdownExporter.exclude_input=True
 # output dir for markdown files relative to working dir NOT notebook dir
-c.FilesWriter.build_directory='pages'
+c.FilesWriter.build_directory='artifacts'
 # output subdir for image files
 c.NbConvertApp.output_files_dir='images'
 c.Preprocessor.enabled=True


### PR DESCRIPTION
Change the output directory for notebook artifacts from 'pages' to 'artifacts' and update related actions accordingly.