### PR TITLE
Update assumptions for net growth rate calculation

### DIFF
--- a/pages/calculator/retirement-calculator.html
+++ b/pages/calculator/retirement-calculator.html
@@ -83,8 +83,8 @@ include_stylesheets:
         <dt><a href="/investment-analytics/inflation.html">Inflation Rate</a></dt>
         <dd>Inflation has remained within the Reserve Bank of Australia's target inflation rate of 2 to 3 percent for over twenty five years.</dd>
         <dt><a href="/investment-analytics/inflation.html">Fund Net Growth Rate</a></dt>
-        <dd>The net growth of funds including dividends and capital gains less fees and taxes. As a baseline comparison the S&P 500 Index has an average growth of ~12% per year excluding fees and taxes.
-            Assume a 50% capital gains tax * 34.5% marginal tax rate = Net growth rate ~ 10%</dd>
+        <dd>The net growth of funds including dividends and capital gains less fees and taxes. As a baseline comparison the S&P 500 Index has an average growth of ~12% per year excluding dividends, fees and taxes.
+            Assume a 50% capital gains tax * 34.5% marginal tax rate = Net growth rate excluding dividends ~ 10%.</dd>
         <dt><a href="/investment-analytics/retirement-expenses.html">Reduced Mobility Expenses</a></dt>
         <dd>The Association of Superannuation Funds of Australia Limited (ASFA) estimate expenses for retirees aged 85 and over are approx 7% lower than those aged 65, because over 85 years any increased medical expenses are offset by significant reduction in travel and leisure expenses.
     </dl>


### PR DESCRIPTION
Clarify the net growth rate assumption by specifying that it excludes dividends, fees, and taxes, providing a more accurate baseline for comparison.