### PR TITLE
Add IPO start price

### DIFF
--- a/data/hash.txt
+++ b/data/hash.txt
@@ -1,7 +1,7 @@
 89a65ffd68f1a1147a11210b567267cb  data/asfa-retirement-standard.md
 08a1026ee8aab13bdfc5b3bc9311d25f  data/f5-data.csv
 3f4d69c0fd6f061af0874ffa731dd553  data/g1-data.csv
-4b34a2e3aeeff52eabc3ccb868b7165c  data/spcx_HistoricalData_2026.csv
+29f33baa1a4ab1461e314c8d8908b25f  data/spcx_HistoricalData_2026.csv
 907e04e7053b30feeaf73032d1741a1c  data/spx_HistoricalData_1940.csv
 16fa747c7d1f89e49cb41bdf94f0b3bf  data/spx_HistoricalData_1950.csv
 b21b540470f15c6217b1239ebce0428b  data/spx_HistoricalData_1960.csv
@@ -16,7 +16,7 @@ dd18c45d4e07d598995a2eb815817194  data/spx_HistoricalData_2021.csv
 2a56d6722eb11883f3e390caae8122d2  data/spx_HistoricalData_2023.csv
 303dec23be37c93529933bdb49872e4d  data/spx_HistoricalData_2024.csv
 4a882e74162e711ea5d9296385649097  data/spx_HistoricalData_2025.csv
-ccf3328e9e1157b6d0d1f9fd979c7ded  data/spx_HistoricalData_2026.csv
+45e8e283d71968a06de8d5e08479a356  data/spx_HistoricalData_2026.csv
 d1ae9f54f14e0f4c7dc841269d65026b  data/tsla_HistoricalData_2010.csv
 23d946417cc7993e39c8315527a15379  data/tsla_HistoricalData_2020.csv
 a51de65bc4f2099dca4807ffd8bd6ee1  data/tsla_HistoricalData_2021.csv
@@ -24,7 +24,7 @@ b6dfeea625b5766eff85aded9088327f  data/tsla_HistoricalData_2022.csv
 0301c3361b9ad876bf76ed33a4a345fb  data/tsla_HistoricalData_2023.csv
 256f9cedef22251250bd7f7bfaf5064c  data/tsla_HistoricalData_2024.csv
 cb8828953a83d49a5e650ecc4363dbdf  data/tsla_HistoricalData_2025.csv
-64f236f705a4d96d7841cd14c6357802  data/tsla_HistoricalData_2026.csv
+83a610ab40ef55daf1bd58e3de191e39  data/tsla_HistoricalData_2026.csv
 492b14b5f19f8a237e0769603e294d7f  data/tsla_PriceTarget_CernBasher.md
 afe6474cc29cba71307e82729f1923b6  data/tsla_PriceTarget_InvestAnswers.md
 9f6bf0a94ce6f7590e4d8021607a4503  data/tsla_PriceTarget_InvestAnswers_2024.md

--- a/notebooks/spcx.ipynb
+++ b/notebooks/spcx.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "ab66e34f",
    "metadata": {},
    "outputs": [],
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "9d10dba8",
    "metadata": {},
    "outputs": [],
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "fd83d499",
    "metadata": {},
    "outputs": [],
@@ -96,6 +96,12 @@
     "df['Date'] = pd.to_datetime(df['Date'], utc=True)\n",
     "df['Date'] = df['Date'].dt.tz_localize(None)\n",
     "df.set_index('Date', inplace=True)\n",
+    "\n",
+    "# Prepend IPO price at IPO date - 1 day so the chart shows the starting price before trading begins\n",
+    "ipo_date = pd.Timestamp('2026-06-12')\n",
+    "ipo_price = 135.0\n",
+    "pre_ipo_row = pd.DataFrame({data_column: [ipo_price]}, index=[ipo_date - pd.Timedelta(days=1)])\n",
+    "df = pd.concat([pre_ipo_row, df])\n",
     "\n",
     "# Set 'last_index' to the last date with a valid value (so I can display 'as of <date>' in chart title)\n",
     "last_index = df[data_column].last_valid_index()"
@@ -293,8 +299,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/spx.ipynb
+++ b/notebooks/spx.ipynb
@@ -114,7 +114,7 @@
     "df.set_index('Date', inplace=True)\n",
     "\n",
     "# Set 'last_index' to the last date with a valid value (so I can display 'as of <date>' in chart title)\n",
-    "last_index = df[data_column].last_valid_index()\n"
+    "last_index = df[data_column].last_valid_index()"
    ]
   },
   {
@@ -312,7 +312,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/tsla.ipynb
+++ b/notebooks/tsla.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "d3822f4f-c72b-4641-b25b-12407a527dc2",
    "metadata": {},
    "outputs": [],
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "df86f343",
    "metadata": {},
    "outputs": [],
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "69615cea",
    "metadata": {},
    "outputs": [],
@@ -105,6 +105,12 @@
     "df['Date'] = pd.to_datetime(df['Date'], utc=True)\n",
     "df['Date'] = df['Date'].dt.tz_localize(None)\n",
     "df.set_index('Date', inplace=True)\n",
+    "\n",
+    "# Prepend IPO price at IPO date - 1 day so the chart shows the starting price before trading begins\n",
+    "ipo_date = pd.Timestamp('2010-06-29')\n",
+    "ipo_price = 17.0 / (5 * 3) # Adjusted for 5:1 stock split in 2020 and 3:1 stock split in 2022\n",
+    "pre_ipo_row = pd.DataFrame({data_column: [ipo_price]}, index=[ipo_date - pd.Timedelta(days=1)])\n",
+    "df = pd.concat([pre_ipo_row, df])\n",
     "\n",
     "# Set 'last_index' to the last date with a valid value (so I can display 'as of <date>' in chart title)\n",
     "last_index = df[data_column].last_valid_index()"
@@ -323,7 +329,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Introduce the IPO start price for the specified dates, allowing the chart to display the starting price before trading begins. Adjustments for stock splits are also included.